### PR TITLE
Begin adding middleware

### DIFF
--- a/internal/derror/error.go
+++ b/internal/derror/error.go
@@ -1,0 +1,17 @@
+// Package derror provides common error handling types.
+package derror
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ServerError is an error to return in the server response.
+type ServerError struct {
+	Status int
+	Err    error
+}
+
+func (s *ServerError) Error() string {
+	return fmt.Sprintf("%d (%s): %v", s.Status, http.StatusText(s.Status), s.Err)
+}

--- a/internal/pg/database.go
+++ b/internal/pg/database.go
@@ -13,26 +13,17 @@ const (
 		TEMPLATE=template0
 		LC_COLLATE='C'
 		LC_CTYPE='C';`
-
-	checkTableExistsQuery = `
-	SELECT EXISTS (
-		SELECT 1
-		FROM information_schema.tables
-		WHERE table_name = $1
-	)`
-
-	createThreadsTableQuery = `
-	CREATE TABLE IF NOT EXISTS threads (
-		id SERIAL PRIMARY KEY,
-		title VARCHAR(100) NOT NULL,
-		body TEXT NOT NULL,
-		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-	);`
 )
 
 // CreateDBIfNotExists creates a new DB with the given name if it doesn't
 // already exist.
-func CreateDBIfNotExists(ctx context.Context, client *Client, name string) error {
+func CreateDBIfNotExists(ctx context.Context, name string) error {
+	client, err := NewClient(ctx, "postgres")
+	if err != nil {
+		return err
+	}
+	defer client.Close(ctx)
+
 	rows, err := client.Query(ctx, "SELECT 1 FROM pg_database WHERE datname = $1 LIMIT 1;", name)
 	if err != nil {
 		return err
@@ -49,56 +40,3 @@ func CreateDBIfNotExists(ctx context.Context, client *Client, name string) error
 	return client.Exec(ctx, query)
 }
 
-func checkTableExists(ctx context.Context, client *Client, name string) (bool, error) {
-	var exists bool
-	err := client.QueryRow(ctx, checkTableExistsQuery, name).Scan(&exists)
-	if err != nil {
-		return false, err
-	}
-
-	if exists {
-		log.Infof(ctx, "Table %s found, no need to create it", name)
-	} else {
-		log.Infof(ctx, "Table %s not found.", name)
-	}
-	return exists, nil
-}
-
-func createThreadsTableIfNotExists(ctx context.Context, client *Client) error {
-	exists, err := checkTableExists(ctx, client, "threads")
-	if err != nil {
-		return err
-	}
-	if !exists {
-		log.Infof(ctx, "Creating threads table")
-		return client.Exec(ctx, createThreadsTableQuery)
-	}
-	return nil
-}
-
-// InitDB initializes the application database.
-func InitDB(ctx context.Context, dbname string) error {
-	// Create a client with the default database name to connect in case
-	// we don't have our app database.
-	client, err := NewClient(ctx, "postgres")
-	if err != nil {
-		return err
-	}
-	defer client.Close(ctx)
-
-	err = CreateDBIfNotExists(ctx, client, dbname)
-	if err != nil {
-		return err
-	}
-
-	// Switch to a client for the app database
-	client, err = NewClient(ctx, dbname)
-	if err != nil {
-		return err
-	}
-	err = createThreadsTableIfNotExists(ctx, client)
-	if err != nil {
-		return err
-	}
-	return nil
-}

--- a/internal/pg/errors.go
+++ b/internal/pg/errors.go
@@ -4,9 +4,10 @@ import "errors"
 
 // Sentinel errors returned by this package.
 var (
-	ErrConnection   = errors.New("connection failed")
-	ErrClientClosed = errors.New("client closed")
-	ErrQueryFailed  = errors.New("query execution failed")
-	ErrDecodeType   = errors.New("decode row failed")
-	ErrEmptyRow     = errors.New("row has 0 columns")
+	ErrConnection          = errors.New("connection failed")
+	ErrClientClosed        = errors.New("client closed")
+	ErrQueryFailed         = errors.New("query execution failed")
+	ErrDecodeType          = errors.New("decode row failed")
+	ErrEmptyRow            = errors.New("row has 0 columns")
+	ErrClientUninitialized = errors.New("client not initialized")
 )

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -2,99 +2,56 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jessesomerville/yodahunters/internal/log"
+	"github.com/jessesomerville/yodahunters/internal/pg"
 )
 
-func (s *Server) handleGetThreads(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	rows, err := s.dbClient.Query(ctx, "SELECT id, title, body, created_at FROM threads")
+func (s *Server) handleGetThreads(w http.ResponseWriter, r *http.Request) error {
+	q := `SELECT id, title, body, created_at FROM threads`
+	threads, err := pg.QueryRowsToStruct[Thread](r.Context(), s.dbClient, q)
 	if err != nil {
-		http.Error(w, "Failed to query DB", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to query DB: %v", err)
+		return err
 	}
-	defer rows.Close()
-	threads, err := pgx.CollectRows(rows, pgx.RowToStructByName[Thread])
-	if err != nil {
-		http.Error(w, "Failed to scan DB results!", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to scan DB results: %v", err)
-	}
-
-	jsonData, err := json.Marshal(threads)
-	if err != nil {
-		http.Error(w, "Failed to marshal threads to JSON", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to marshal threads to JSON %v", threads)
-	}
-
-	w.Write(jsonData)
+	return json.NewEncoder(w).Encode(threads)
 }
 
-func (s *Server) handleGetThreadByID(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleGetThreadByID(w http.ResponseWriter, r *http.Request) error {
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
-		http.Error(w, "Error retrieving ID from Path", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Error retrieving ID from Path, ID: %d", id)
+		return fmt.Errorf("invalid thread ID %q", r.PathValue("id"))
 	}
 
-	ctx := r.Context()
-
-	var thread Thread
-	err = s.dbClient.QueryRow(ctx, "SELECT id, title, body, created_at FROM threads WHERE id = $1", id).
-		Scan(&thread.ID, &thread.Title, &thread.Body, &thread.CreatedAt)
+	q := `SELECT id, title, body, created_at FROM threads WHERE id = $1`
+	thread, err := pg.QueryRowToStruct[Thread](r.Context(), s.dbClient, q, id)
 	if err != nil {
-		http.Error(w, "Failed to retrieve thread!", http.StatusInternalServerError)
-		log.Errorf(ctx, "Failed to retrieve thread with ID: %d", id)
+		return err
 	}
-
-	jsonData, err := json.Marshal(thread)
-	if err != nil {
-		http.Error(w, "Failed to marshal thread to JSON", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to marshal thread to JSON %v", thread)
-	}
-
-	w.Write(jsonData)
+	return json.NewEncoder(w).Encode(thread)
 }
 
-func (s *Server) handlePostThreads(w http.ResponseWriter, r *http.Request) {
-	const insertThreadQuery = `
+func (s *Server) handlePostThreads(w http.ResponseWriter, r *http.Request) error {
+	reqBody, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		return err
+	}
+	var t Thread
+	if err := json.Unmarshal(reqBody, &t); err != nil {
+		return err
+	}
+
+	const q = `
 	INSERT INTO threads (title, body)
 	VALUES ($1, $2)
 	RETURNING id, title, body, created_at`
 
-	defer r.Body.Close()
-
-	bodyBytes, err := io.ReadAll(r.Body)
+	thread, err := pg.QueryRowToStruct[Thread](r.Context(), s.dbClient, q, t.Title, t.Body)
 	if err != nil {
-		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to read request body!")
+		return err
 	}
-
-	var t Thread
-	if err = json.Unmarshal(bodyBytes, &t); err != nil {
-		http.Error(w, "Failed to parse request JSON", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to parse request JSON!")
-	}
-
-	ctx := r.Context()
-
-	var thread Thread
-	err = s.dbClient.QueryRow(ctx, insertThreadQuery, t.Title, t.Body).
-		Scan(&thread.ID, &thread.Title, &thread.Body, &thread.CreatedAt)
-	if err != nil {
-		http.Error(w, "Failed to update threads table", http.StatusInternalServerError)
-		log.Errorf(ctx, "Couldn't update threads table!")
-	}
-
-	jsonData, err := json.Marshal(thread)
-	if err != nil {
-		http.Error(w, "Failed to marshal thread to JSON", http.StatusInternalServerError)
-		log.Errorf(r.Context(), "Failed to marshal thread to JSON %v", thread)
-	}
-
-	w.Write(jsonData)
+	return json.NewEncoder(w).Encode(thread)
 }

--- a/internal/server/middleware/error.go
+++ b/internal/server/middleware/error.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/jessesomerville/yodahunters/internal/derror"
+	"github.com/jessesomerville/yodahunters/internal/log"
+)
+
+// ErrorHandler handles responding to requests with error messages.
+func ErrorHandler(f func(w http.ResponseWriter, r *http.Request) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := f(w, r); err != nil {
+			var serr *derror.ServerError
+			if !errors.As(err, &serr) {
+				serr = &derror.ServerError{Status: http.StatusInternalServerError, Err: err}
+			}
+			log.Errorf(r.Context(), "returning %d (%s) for error %v", serr.Status, http.StatusText(serr.Status), err)
+			http.Error(w, serr.Err.Error(), serr.Status)
+		}
+	}
+}

--- a/internal/server/middleware/middleware.go
+++ b/internal/server/middleware/middleware.go
@@ -1,0 +1,2 @@
+// Package middleware implements middleware HTTP handlers.
+package middleware

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jessesomerville/yodahunters/internal/envconfig"
 	"github.com/jessesomerville/yodahunters/internal/log"
 	"github.com/jessesomerville/yodahunters/internal/pg"
+	"github.com/jessesomerville/yodahunters/internal/server/middleware"
 	"github.com/jessesomerville/yodahunters/internal/templates"
 )
 
@@ -44,10 +45,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 	dbname := envconfig.GetEnvOrDefault("YODAHUNTERS_DATABASE_NAME", "yodahunters-db")
-	// if err := pg.CreateDBIfNotExists(ctx, dbname); err != nil {
-	// 	return err
-	// }
-	if err := pg.InitDB(ctx, dbname); err != nil {
+	if err := pg.CreateDBIfNotExists(ctx, dbname); err != nil {
 		return err
 	}
 
@@ -71,9 +69,9 @@ func Run(ctx context.Context, cfg Config) error {
 	mux.Handle("/", s.handleHome())
 
 	apiMux := http.NewServeMux()
-	apiMux.HandleFunc("GET /threads", s.handleGetThreads)
-	apiMux.HandleFunc("GET /threads/{id}", s.handleGetThreadByID)
-	apiMux.HandleFunc("POST /threads", s.handlePostThreads)
+	apiMux.Handle("GET /threads", middleware.ErrorHandler(s.handleGetThreads))
+	apiMux.Handle("GET /threads/{id}", middleware.ErrorHandler(s.handleGetThreadByID))
+	apiMux.Handle("POST /threads", middleware.ErrorHandler(s.handlePostThreads))
 	// TODO: delete
 
 	mux.Handle("/api/", http.StripPrefix("/api", apiMux))


### PR DESCRIPTION
- Moved error handing from api.go to internal/server/middleware/errors.go
- Abstracted some query logic into `QueryRowsToStruct` and `QueryRowToStruct`
- Removed table creation logic and checks for table existence since that should be delegated to migrate


Planned follow-up changes:

- Add `serveJSON` handler that can wrap other handlers that return structs and write them as JSON to the response
- Add `middleware.Middleware` type that can be chained together and wrap `mux` to handle common stuff like dealing with panics, universal response headers, verbose debug logging, etc