### PR TITLE
Adding authorization middleware

### DIFF
--- a/devtools/test_api.sh
+++ b/devtools/test_api.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S bash -e
+
+# Script for testing api endpoints after authz has been applied
+# This just logs in and adds the cookie to a curl command to 
+# make our lives a little easier.
+# usage: ./devtools/test_api.sh username password [curl arguments ...]
+token_regex="\"(eyJ.+)\""
+username=$1
+password=$2
+shift 2
+token_response=`curl -sS -X POST -d "{\"username\":\"$username\", \"password\":\"$password\"}" http://localhost:8080/api/login`
+if [[ $token_response =~ $token_regex ]] 
+then
+    curl --cookie access_token=$BASH_REMATCH[1] "$@"
+else
+    echo "Failed to login!"
+fi

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/jessesomerville/yodahunters/internal/pg"
+	"github.com/jessesomerville/yodahunters/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -121,7 +122,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	jwt, err := GenerateJWT(id, s.jwtSecret)
+	jwt, err := middleware.GenerateJWT(id, s.jwtSecret)
 	if err != nil {
 		return err
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -160,3 +160,14 @@ func (s *Server) apiHandleLogin(w http.ResponseWriter, r *http.Request) error {
 
 	return json.NewEncoder(w).Encode(token)
 }
+
+func (s *Server) apiHandleMe(w http.ResponseWriter, r *http.Request) error {
+	const q = "SELECT id, username, email, created_at FROM users WHERE id = $1"
+	row, err := s.dbClient.QueryRow(r.Context(), q, r.Context().Value(middleware.CtxUserKey))
+	if err != nil {
+		return err
+	}
+	var user User
+	row.Scan(&user.ID, &user.Username, &user.Email, &user.CreatedAt)
+	return json.NewEncoder(w).Encode(user)
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) apiHandleGetThreads(w http.ResponseWriter, r *http.Request) error {
-	q := `SELECT id, author_id, title, body, created_at FROM threads`
+	q := `SELECT thread_id, author_id, title, body, created_at FROM threads`
 	threads, err := pg.QueryRowsToStruct[Thread](r.Context(), s.dbClient, q)
 	if err != nil {
 		return err

--- a/internal/server/middleware/authentication.go
+++ b/internal/server/middleware/authentication.go
@@ -1,4 +1,4 @@
-package server
+package middleware
 
 import (
 	"bytes"

--- a/internal/server/middleware/authentication.go
+++ b/internal/server/middleware/authentication.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"strings"
 	"time"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 type joseHeader struct {
@@ -33,8 +31,9 @@ type JWT struct {
 
 // GenerateJWT takes a user id and the signing secret and generates a JWT.
 // with the following structure:
-//  Header: {"alg":"HS256", "typ":"JWT"}
-//  Claims: {"user_id": user_id, "exp": [current time + 12hrs]}
+//
+//	Header: {"alg":"HS256", "typ":"JWT"}
+//	Claims: {"user_id": user_id, "exp": [current time + 12hrs]}
 func GenerateJWT(userID int, secret []byte) (JWT, error) {
 	// Set the header and payload
 	jwt := JWT{
@@ -72,9 +71,9 @@ func GenerateJWT(userID int, secret []byte) (JWT, error) {
 // with the fields filled out appropriately.
 func ParseJWT(s string) (JWT, error) {
 	jwtParts := strings.Split(s, ".")
-  if len(jwtParts) != 3 {
-    return JWT{}, errors.New("malformed JWT")
-  }
+	if len(jwtParts) != 3 {
+		return JWT{}, errors.New("malformed JWT")
+	}
 	headerBytes, err := base64.RawURLEncoding.DecodeString(jwtParts[0])
 	if err != nil {
 		return JWT{}, err
@@ -125,25 +124,4 @@ func (j *JWT) IsValid(secret []byte) (bool, error) {
 		return true, nil
 	}
 	return false, nil
-}
-
-// GeneratePasswordHash adds a hashed password to a User struct if  there is a
-// password in the struct, and a password hash is not already present.
-func (u *User) GeneratePasswordHash() error {
-	// If no password is provided, then it should be set to an empty string.
-	// It shouldn't be possible to set an empty string as a password in any case.
-	if u.PasswordHash != nil {
-		return errors.New("user struct already contains password hash")
-	}
-	if u.Password == "" {
-		return errors.New("attempted to generate password hash where password is an empty string")
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
-	if err != nil {
-		return err
-	}
-	u.PasswordHash = hash
-	u.Password = ""
-	return nil
 }

--- a/internal/server/middleware/authorization.go
+++ b/internal/server/middleware/authorization.go
@@ -30,5 +30,6 @@ func AuthorizationHandler(next http.HandlerFunc, secret []byte) http.HandlerFunc
 		if !isAuthenticated(r, secret) {
 			http.Redirect(w, r, "/login", http.StatusFound)
 		}
+		next.ServeHTTP(w, r)
 	}
 }

--- a/internal/server/middleware/authorization.go
+++ b/internal/server/middleware/authorization.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/jessesomerville/yodahunters/internal/log"
+)
+
+func isAuthenticated(r *http.Request, secret []byte) bool {
+	accessToken, err := r.Cookie("access_token")
+	if err != nil {
+		log.Errorf(r.Context(), "failed to read access_token cookie")
+		return false
+	}
+	jwt, err := ParseJWT(accessToken.Value)
+	if err != nil {
+		log.Errorf(r.Context(), "failed to parse jwt in access_token cookie")
+		return false
+	}
+	valid, err := jwt.IsValid(secret)
+	if err != nil {
+		log.Errorf(r.Context(), "unable to validate JWT")
+		return false
+	}
+	return valid
+}
+
+func AuthorizationHandler(next http.HandlerFunc, secret []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isAuthenticated(r, secret) {
+			http.Redirect(w, r, "/login", http.StatusFound)
+		}
+	}
+}

--- a/internal/server/middleware/authorization.go
+++ b/internal/server/middleware/authorization.go
@@ -1,35 +1,28 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
-
-	"github.com/jessesomerville/yodahunters/internal/log"
 )
 
-func isAuthenticated(r *http.Request, secret []byte) bool {
+// Authorize takes a request, verifies that it contains a valid
+// JWT, then returns the user id for that the user in the JWT.
+func Authorize(r *http.Request, secret []byte) (int, error) {
 	accessToken, err := r.Cookie("access_token")
 	if err != nil {
-		log.Errorf(r.Context(), "failed to read access_token cookie")
-		return false
+		return -1, err
 	}
 	jwt, err := ParseJWT(accessToken.Value)
 	if err != nil {
-		log.Errorf(r.Context(), "failed to parse jwt in access_token cookie")
-		return false
+		return -1, err
 	}
 	valid, err := jwt.IsValid(secret)
 	if err != nil {
-		log.Errorf(r.Context(), "unable to validate JWT")
-		return false
+		return -1, err
 	}
-	return valid
-}
+	if !valid {
+		return -1, errors.New("invalid JWT")
+	}
 
-func AuthorizationHandler(next http.HandlerFunc, secret []byte) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if !isAuthenticated(r, secret) {
-			http.Redirect(w, r, "/login", http.StatusFound)
-		}
-		next.ServeHTTP(w, r)
-	}
+	return jwt.Payload.UserID, nil
 }

--- a/internal/server/middleware/middleware.go
+++ b/internal/server/middleware/middleware.go
@@ -1,2 +1,26 @@
 // Package middleware implements middleware HTTP handlers.
 package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+type CtxKey string
+
+const CtxUserKey CtxKey = "userID"
+
+func AuthorizationHandler(next http.HandlerFunc, secret []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, err := Authorize(r, secret)
+		if err != nil {
+			http.Redirect(w, r, "/login", http.StatusFound)
+		}
+		ctx := context.WithValue(r.Context(), CtxUserKey, userID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+}
+
+func MiddlewareChain(f func(w http.ResponseWriter, r *http.Request) error, jwtSecret []byte) http.HandlerFunc {
+	return AuthorizationHandler(ErrorHandler(f), jwtSecret)
+}

--- a/internal/server/middleware/middleware.go
+++ b/internal/server/middleware/middleware.go
@@ -6,10 +6,14 @@ import (
 	"net/http"
 )
 
-type CtxKey string
+type ctxKey string
 
-const CtxUserKey CtxKey = "userID"
+// CtxUserKey is used to set and retrieve the user ID from a request context.
+const CtxUserKey ctxKey = "userID"
 
+// AuthorizationHandler verifies that a request has a valid access token in the
+// cookie, retrieves the user_id set in the access token, and adds the user_id
+// to the request context.
 func AuthorizationHandler(next http.HandlerFunc, secret []byte) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID, err := Authorize(r, secret)
@@ -21,6 +25,8 @@ func AuthorizationHandler(next http.HandlerFunc, secret []byte) http.HandlerFunc
 	}
 }
 
-func MiddlewareChain(f func(w http.ResponseWriter, r *http.Request) error, jwtSecret []byte) http.HandlerFunc {
+// Chain links all the middleware handlers together to make it convenient to call them all
+// in a row.
+func Chain(f func(w http.ResponseWriter, r *http.Request) error, jwtSecret []byte) http.HandlerFunc {
 	return AuthorizationHandler(ErrorHandler(f), jwtSecret)
 }

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -2,7 +2,10 @@ package server
 
 // TODO.
 import (
+	"errors"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 // User is a struct for managing users in the app.
@@ -24,4 +27,25 @@ type Thread struct {
 	Title     string    `json:"Title" db:"title"`
 	Body      string    `json:"Body" db:"body"`
 	CreatedAt time.Time `json:"created_at,omitempty" db:"created_at"`
+}
+
+// GeneratePasswordHash adds a hashed password to a User struct if  there is a
+// password in the struct, and a password hash is not already present.
+func (u *User) GeneratePasswordHash() error {
+	// If no password is provided, then it should be set to an empty string.
+	// It shouldn't be possible to set an empty string as a password in any case.
+	if u.PasswordHash != nil {
+		return errors.New("user struct already contains password hash")
+	}
+	if u.Password == "" {
+		return errors.New("attempted to generate password hash where password is an empty string")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	u.PasswordHash = hash
+	u.Password = ""
+	return nil
 }

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -23,9 +23,10 @@ type User struct {
 
 // Thread is a simplified struct for testing thread functionality.
 type Thread struct {
-	ID        int       `json:"id,omitempty" db:"id"`
-	Title     string    `json:"Title" db:"title"`
-	Body      string    `json:"Body" db:"body"`
+	ID        int       `json:"thread_id,omitempty" db:"thread_id"`
+	Title     string    `json:"title" db:"title"`
+	Body      string    `json:"body" db:"body"`
+	AuthorID  string    `json:"author_id,omitempty" db:"author_id"`
 	CreatedAt time.Time `json:"created_at,omitempty" db:"created_at"`
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", middleware.AuthorizationHandler(middleware.ErrorHandler(s.handleHome), s.jwtSecret))
+	mux.Handle("/", middleware.MiddlewareChain(s.handleHome, s.jwtSecret))
 	mux.Handle("/login", middleware.ErrorHandler(s.handleLogin))
 
 	apiMux := http.NewServeMux()
@@ -88,6 +88,8 @@ func Run(ctx context.Context, cfg Config) error {
 	// TODO: delete
 	apiMux.HandleFunc("POST /register", middleware.ErrorHandler(s.apiHandleRegister))
 	apiMux.HandleFunc("POST /login", middleware.ErrorHandler(s.apiHandleLogin))
+
+	apiMux.HandleFunc("GET /me", middleware.MiddlewareChain(s.apiHandleMe, s.jwtSecret))
 
 	mux.Handle("/api/", http.StripPrefix("/api", apiMux))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,7 @@ func Run(ctx context.Context, cfg Config) error {
 	apiMux := http.NewServeMux()
 	apiMux.Handle("GET /threads", middleware.ErrorHandler(s.apiHandleGetThreads))
 	apiMux.Handle("GET /threads/{id}", middleware.ErrorHandler(s.apiHandleGetThreadByID))
-	apiMux.Handle("POST /threads", middleware.ErrorHandler(s.apiHandlePostThreads))
+	apiMux.Handle("POST /threads", middleware.MiddlewareChain(s.apiHandlePostThreads, s.jwtSecret))
 	// TODO: delete
 	apiMux.HandleFunc("POST /register", middleware.ErrorHandler(s.apiHandleRegister))
 	apiMux.HandleFunc("POST /login", middleware.ErrorHandler(s.apiHandleLogin))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,8 +78,8 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", middleware.ErrorHandler(middleware.AuthorizationHandler(s.handleHome))
-	mux.Handle("/login", middleware.ErrorHandler(s.handleLogin), s.jwtSecret))
+	mux.Handle("/", middleware.AuthorizationHandler(middleware.ErrorHandler(s.handleHome), s.jwtSecret))
+	mux.Handle("/login", middleware.ErrorHandler(s.handleLogin))
 
 	apiMux := http.NewServeMux()
 	apiMux.Handle("GET /threads", middleware.ErrorHandler(s.apiHandleGetThreads))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,18 +78,18 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", middleware.MiddlewareChain(s.handleHome, s.jwtSecret))
+	mux.Handle("/", middleware.Chain(s.handleHome, s.jwtSecret))
 	mux.Handle("/login", middleware.ErrorHandler(s.handleLogin))
 
 	apiMux := http.NewServeMux()
 	apiMux.Handle("GET /threads", middleware.ErrorHandler(s.apiHandleGetThreads))
 	apiMux.Handle("GET /threads/{id}", middleware.ErrorHandler(s.apiHandleGetThreadByID))
-	apiMux.Handle("POST /threads", middleware.MiddlewareChain(s.apiHandlePostThreads, s.jwtSecret))
+	apiMux.Handle("POST /threads", middleware.Chain(s.apiHandlePostThreads, s.jwtSecret))
 	// TODO: delete
 	apiMux.HandleFunc("POST /register", middleware.ErrorHandler(s.apiHandleRegister))
 	apiMux.HandleFunc("POST /login", middleware.ErrorHandler(s.apiHandleLogin))
 
-	apiMux.HandleFunc("GET /me", middleware.MiddlewareChain(s.apiHandleMe, s.jwtSecret))
+	apiMux.HandleFunc("GET /me", middleware.Chain(s.apiHandleMe, s.jwtSecret))
 
 	mux.Handle("/api/", http.StripPrefix("/api", apiMux))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", s.handleHome())
+	mux.Handle("/", middleware.AuthorizationHandler(s.handleHome(), s.jwtSecret))
 
 	apiMux := http.NewServeMux()
 	apiMux.Handle("GET /threads", middleware.ErrorHandler(s.handleGetThreads))

--- a/migrations/000003_add_author_id_to_threads_table.down.sql
+++ b/migrations/000003_add_author_id_to_threads_table.down.sql
@@ -1,0 +1,7 @@
+-- add_author_id_to_threads_table (2025-12-09)
+
+BEGIN;
+
+ALTER TABLE threads DROP COLUMN author_id;
+
+END;

--- a/migrations/000003_add_author_id_to_threads_table.up.sql
+++ b/migrations/000003_add_author_id_to_threads_table.up.sql
@@ -1,0 +1,7 @@
+-- add_author_id_to_threads_table (2025-12-09)
+
+BEGIN;
+
+ALTER TABLE threads ADD COLUMN author_id INT REFERENCES users(id)
+
+END;


### PR DESCRIPTION
- **adding authz**
- **refactor authz middleware**
- **added author_id to threads table**
- **added migration for author_id in threads table**
- **adding convenience wrapper for curl**
- **updating thread_id column in query**
- **used the linter locally this time**

Yeah that's a summary of the commits up there. I wanted to give this to you for review before I made too many
changes. I feel like there's a better way to do the middleware chain, but since both our middlewares have
different function signatures, there's not a straighforward way to link them other than typing them all
the way out. Maybe there's a way to stuff the parameters into request contexts? IDK if that's a better
solution.
